### PR TITLE
Use Shadow DOM to isolate sidebar from page DOM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 web-ext-artifacts
 _metadata
 screenshots
+manifest.json

--- a/early.js
+++ b/early.js
@@ -1,0 +1,8 @@
+// Runs at document_start (before first paint) to prevent layout flash.
+// Adds the class that triggers the margin-right rule from sidehn.css.
+(function () {
+  var match = location.search.match(/[?&]hnid=(\d+)/);
+  if (match && window.innerWidth >= 1024) {
+    document.documentElement.classList.add("sidehn-active");
+  }
+})();

--- a/early.js
+++ b/early.js
@@ -1,8 +1,11 @@
-// Runs at document_start (before first paint) to prevent layout flash.
-// Adds the class that triggers the margin-right rule from sidehn.css.
+// Runs at document_start (before first paint) to prevent layout flash
+// and capture the hnid before the page can strip it from the URL.
 (function () {
   var match = location.search.match(/[?&]hnid=(\d+)/);
-  if (match && window.innerWidth >= 1024) {
-    document.documentElement.classList.add("sidehn-active");
+  if (match) {
+    document.documentElement.dataset.sidehnId = match[1];
+    if (window.innerWidth >= 1024) {
+      document.documentElement.classList.add("sidehn-active");
+    }
   }
 })();

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "SideHN",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "description": "The web, with a side of HackerNews. Shows a sidebar with HN comments if the link was opened from HN",
   "author": "Alin Panaitiu",
   "homepage_url": "https://github.com/alin23/sidehn",

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -23,6 +23,12 @@
   ],
   "content_scripts": [
     {
+      "matches": ["*://*/*?*hnid=*"],
+      "css": ["sidehn.css"],
+      "js": ["early.js"],
+      "run_at": "document_start"
+    },
+    {
       "matches": ["https://news.ycombinator.com/*", "*://*/*?*hnid=*"],
       "js": ["browser-polyfill.min.js", "script.js"],
       "run_at": "document_end"

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -31,7 +31,8 @@
     {
       "matches": ["https://news.ycombinator.com/*", "*://*/*?*hnid=*"],
       "js": ["browser-polyfill.min.js", "script.js"],
-      "run_at": "document_end"
+      "run_at": "document_end",
+      "all_frames": true
     }
   ],
   "minimum_chrome_version": "102.0",

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "SideHN",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "The web, with a side of HackerNews. Shows a sidebar with HN comments if the link was opened from HN",
   "author": "Alin Panaitiu",
   "homepage_url": "https://github.com/alin23/sidehn",

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -23,6 +23,12 @@
   ],
   "content_scripts": [
     {
+      "matches": ["*://*/*?*hnid=*"],
+      "css": ["sidehn.css"],
+      "js": ["early.js"],
+      "run_at": "document_start"
+    },
+    {
       "matches": ["https://news.ycombinator.com/*", "*://*/*?*hnid=*"],
       "js": ["browser-polyfill.min.js", "script.js"],
       "run_at": "document_end"

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -31,7 +31,8 @@
     {
       "matches": ["https://news.ycombinator.com/*", "*://*/*?*hnid=*"],
       "js": ["browser-polyfill.min.js", "script.js"],
-      "run_at": "document_end"
+      "run_at": "document_end",
+      "all_frames": true
     }
   ],
   "minimum_chrome_version": "102.0",

--- a/rules.json
+++ b/rules.json
@@ -46,5 +46,42 @@
     "condition": {
       "urlFilter": "||news.ycombinator.com"
     }
+  },
+  {
+    "id": 4,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "responseHeaders": [
+        {
+          "operation": "remove",
+          "header": "Content-Security-Policy"
+        },
+        {
+          "operation": "remove",
+          "header": "X-Frame-Options"
+        },
+        {
+          "operation": "remove",
+          "header": "Frame-Options"
+        },
+        {
+          "operation": "remove",
+          "header": "Cross-Origin-Embedder-Policy"
+        },
+        {
+          "operation": "remove",
+          "header": "Cross-Origin-Opener-Policy"
+        },
+        {
+          "operation": "remove",
+          "header": "Cross-Origin-Resource-Policy"
+        }
+      ]
+    },
+    "condition": {
+      "urlFilter": "hnid=",
+      "resourceTypes": ["main_frame"]
+    }
   }
 ]

--- a/script.js
+++ b/script.js
@@ -1,128 +1,143 @@
-window.addHNComments = (id) => {
-  // Create the iframe element
-  if (document.getElementById("hn-iframe")) {
+function addHNComments(id) {
+  // Prevent duplicate injection
+  if (document.querySelector("sidehn-host")) {
     return;
   }
+
+  // State — kept in closure, not on window
+  let shown = false;
+  let hiddenManually = false;
+
+  // Create a custom-element host and attach a closed shadow root.
+  // Closed mode means the page cannot access shadowRoot at all.
+  const host = document.createElement("sidehn-host");
+  host.style.cssText = "all:initial; position:fixed; top:0; right:0; z-index:2147483647; width:0; height:0; pointer-events:none;";
+  const shadow = host.attachShadow({ mode: "closed" });
+
+  // Inject styles into the shadow — completely isolated from the page
+  const style = document.createElement("style");
+  style.textContent = `
+    :host { all: initial; }
+
+    #hn-iframe {
+      position: fixed;
+      top: 0;
+      right: -30%;
+      width: 30%;
+      height: 100vh;
+      border: none;
+      z-index: 2147483647;
+      transition: right 0.2s ease;
+      pointer-events: auto;
+    }
+    #hn-iframe.visible {
+      right: 0;
+    }
+
+    #hn-toggle {
+      position: fixed;
+      top: calc(50% - 1.5rem);
+      right: 0;
+      height: 3rem;
+      width: 1.5rem;
+      background: hsla(21, 84%, 55%, 1.00);
+      font-size: 1.5rem;
+      cursor: pointer;
+      outline: none;
+      border: none;
+      color: black;
+      border-radius: 0.5rem 0 0 0.5rem;
+      z-index: 2147483647;
+      transition: right 0.2s ease;
+      pointer-events: auto;
+      font-family: sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+    }
+    #hn-toggle.visible {
+      right: 30%;
+    }
+
+    @media (max-width: 1023px) {
+      #hn-iframe { width: 85%; right: -85%; }
+      #hn-iframe.visible { right: 0; }
+      #hn-toggle.visible { right: 85%; }
+    }
+  `;
+  shadow.appendChild(style);
+
+  // Iframe
   const iframe = document.createElement("iframe");
   iframe.id = "hn-iframe";
-  const bodyStyle = getComputedStyle(document.body);
-
-  // Set the source of the iframe to the Hacker News comments page for the given URL
   iframe.src = `https://news.ycombinator.com/item?id=${id}`;
+  shadow.appendChild(iframe);
 
-  // Set the width and height of the iframe
-  iframe.style.width = "30%";
-  iframe.style.minWidth = "30%";
-  iframe.style.maxWidth = "30%";
-  iframe.style.height = "100%";
-  iframe.style.position = "fixed";
-  iframe.style.top = "0";
-  iframe.style.right = "-30%";
-  iframe.style.zIndex = 1000;
+  // Toggle button
+  const toggle = document.createElement("button");
+  toggle.id = "hn-toggle";
+  toggle.textContent = "\u25C2"; // left-pointing chevron (collapsed)
+  shadow.appendChild(toggle);
 
-  // Create the close button (a right chevron placed on the left side of the iframe)
-  const closeButton = document.createElement("button");
-  closeButton.innerHTML = window.innerWidth >= 1024 ? "&#9656;" : "&#9666;";
-  closeButton.style.position = "fixed";
-  closeButton.style.top = "calc(50% - 3rem)";
-  closeButton.style.right = "0";
-  closeButton.style.height = "3rem";
-  closeButton.style.width = "1.5rem";
-  closeButton.style.backgroundColor = "hsla(21, 84%, 55%, 1.00)";
-  closeButton.style.fontSize = "1.5rem";
-  closeButton.style.cursor = "pointer";
-  closeButton.style.outline = "none";
-  closeButton.style.color = "black";
-  closeButton.style.borderRadius = "0.5rem 0 0 0.5rem";
-  closeButton.style.zIndex = 1001;
+  // Inject a <style> into the page to shrink body — the only page-side effect.
+  // Using an ID so we can toggle it without touching the page's own styles.
+  const pageStyle = document.createElement("style");
+  pageStyle.id = "sidehn-page-style";
+  pageStyle.textContent = `
+    html.sidehn-active {
+      margin-right: 30% !important;
+      transition: margin-right 0.2s ease;
+    }
+    @media (max-width: 1023px) {
+      html.sidehn-active {
+        margin-right: 0 !important;
+      }
+    }
+  `;
+  document.head.appendChild(pageStyle);
 
-  window.hnIframeHiddenManually = false;
-  closeButton.addEventListener("click", () => {
-    if (window.hnIframeShown) {
-      window.hnIframeHiddenManually = true;
-      window.hideHNComments();
+  function show() {
+    shown = true;
+    iframe.classList.add("visible");
+    toggle.classList.add("visible");
+    toggle.textContent = "\u25B8"; // right-pointing chevron (expanded)
+    document.documentElement.classList.add("sidehn-active");
+  }
+
+  function hide() {
+    shown = false;
+    iframe.classList.remove("visible");
+    toggle.classList.remove("visible");
+    toggle.textContent = "\u25C2";
+    document.documentElement.classList.remove("sidehn-active");
+  }
+
+  toggle.addEventListener("click", () => {
+    if (shown) {
+      hiddenManually = true;
+      hide();
     } else {
-      window.hnIframeHiddenManually = false;
-      window.showHNComments();
+      hiddenManually = false;
+      show();
     }
   });
 
-  window.hideHNComments = () => {
-    iframe.style.right = "-30%";
-    closeButton.innerHTML = "&#9666;";
-    document.getElementById("hn-iframe-placeholder").style.display = "none";
-
-    const bodyContainer = document.getElementById("hn-body-container");
-    bodyContainer.style.maxWidth = "100%";
-    bodyContainer.style.width = "100%";
-    bodyContainer.style.flex = 1;
-    window.hnIframeShown = false;
-  };
-
-  window.showHNComments = () => {
-    iframe.style.right = "0";
-    closeButton.innerHTML = "&#9656;";
-    document.getElementById("hn-iframe-placeholder").style.display = "block";
-
-    const bodyContainer = document.getElementById("hn-body-container");
-    bodyContainer.style.maxWidth = "70%";
-    bodyContainer.style.width = `calc(70% - ${bodyStyle.padding || 0})`;
-    bodyContainer.style.flex = 0.7;
-    window.hnIframeShown = true;
-  };
-
-  // Create a flex container to hold the website contents and the iframe
-  const flexContainer = document.createElement("div");
-  flexContainer.id = "hn-flex-container";
-  flexContainer.style.display = "flex";
-
-  // Container for holding the body contents
-  const bodyContainer = document.createElement("div");
-  bodyContainer.id = "hn-body-container";
-  bodyContainer.style.flexGrow = 0.7;
-  bodyContainer.style.width = `calc(70% - ${bodyStyle.padding || 0})`;
-  bodyContainer.style.minWidth = "50%";
-  bodyContainer.style.maxWidth = "70%";
-  bodyContainer.style.margin = bodyStyle.margin;
-  bodyContainer.style.padding = bodyStyle.padding;
-  bodyContainer.innerHTML = document.body.innerHTML;
-  flexContainer.innerHTML = bodyContainer.outerHTML;
-
-  // Create a placeholder for the iframe that will be 30% of the flex container
-  // to push body contents to the left of the sidebar
-  const iframePlaceholder = document.createElement("div");
-  iframePlaceholder.id = "hn-iframe-placeholder";
-  iframePlaceholder.style.width = "30%";
-  iframePlaceholder.style.minWidth = "30%";
-  iframePlaceholder.style.maxWidth = "30%";
-  iframePlaceholder.style.height = "100vh";
-  iframePlaceholder.style.flex = 0.3;
-  iframePlaceholder.style.backgroundColor = "hsla(60, 25%, 95%, 1.00)";
-
-  flexContainer.appendChild(iframePlaceholder);
-  document.body.innerHTML = flexContainer.outerHTML;
-  document.body.appendChild(iframe);
-  document.body.appendChild(closeButton);
-  document.body.style.margin = 0;
-  document.body.style.padding = 0;
-  document.body.style.width = "100%";
-  document.body.style.minWidth = "100%";
-  document.body.style.maxWidth = "100%";
-
-  // Show/hide the iframe based on the width of the page
-  function toggleIframe() {
+  function autoToggle() {
     if (window.innerWidth < 1024) {
-      window.hideHNComments();
-    } else if (!window.hnIframeHiddenManually) {
-      window.showHNComments();
+      hide();
+    } else if (!hiddenManually) {
+      show();
     }
   }
 
-  // Call toggleIframe on page load and on window resize
-  window.addEventListener("load", toggleIframe);
-  window.addEventListener("resize", toggleIframe);
-  toggleIframe();
-};
+  // Append the shadow host to documentElement (not body) so SPA body
+  // replacements don't remove it
+  document.documentElement.appendChild(host);
+
+  window.addEventListener("resize", autoToggle);
+  autoToggle();
+}
 
 function addHashIDs() {
   var hnItems = document.querySelectorAll("tr.athing");

--- a/script.js
+++ b/script.js
@@ -163,13 +163,9 @@ function addHashIDs() {
       item.querySelector("a.hn-item-title");
     if (!link) return;
     if (!link.href.includes("news.ycombinator.com")) {
-      if (link.href.match(/([?&])hnid=\d+/)) {
-        link.href = link.href.replace(/([?&])hnid=\d+/, `$1hnid=${item.id}`);
-      } else if (link.href.includes("?")) {
-        link.href += `&hnid=${item.id}`;
-      } else {
-        link.href += `?hnid=${item.id}`;
-      }
+      const url = new URL(link.href);
+      url.searchParams.set("hnid", item.id);
+      link.href = url.toString();
     }
   });
 }

--- a/script.js
+++ b/script.js
@@ -175,13 +175,13 @@ async function setup() {
 
     const hnidMatch = location.search.match(/[?&]hnid=(\d+)/);
     if (hnidMatch) {
-      window.addHNComments(hnidMatch[1]);
+      addHNComments(hnidMatch[1]);
     }
     return;
   }
 
-  window.hnObserver = new MutationObserver(addHashIDs);
-  window.hnObserver.observe(document.body, {
+  const observer = new MutationObserver(addHashIDs);
+  observer.observe(document.body, {
     childList: true,
     subtree: true,
   });

--- a/script.js
+++ b/script.js
@@ -11,7 +11,7 @@ function addHNComments(id) {
   // Create a custom-element host and attach a closed shadow root.
   // Closed mode means the page cannot access shadowRoot at all.
   const host = document.createElement("sidehn-host");
-  host.style.cssText = "all:initial; position:fixed; top:0; right:0; z-index:2147483647; width:0; height:0; pointer-events:none;";
+  host.style.cssText = "position:fixed; top:0; right:0; z-index:2147483647; width:0; height:0; pointer-events:none; display:block;";
   const shadow = host.attachShadow({ mode: "closed" });
 
   // Inject styles into the shadow — completely isolated from the page
@@ -26,6 +26,7 @@ function addHNComments(id) {
       width: 30%;
       height: 100vh;
       border: none;
+      border-left: 1px solid rgba(0, 0, 0, 0.12);
       z-index: 2147483647;
       pointer-events: auto;
     }
@@ -160,6 +161,7 @@ function addHashIDs() {
     const link =
       item.querySelector("span.titleline > a") ||
       item.querySelector("a.hn-item-title");
+    if (!link) return;
     if (!link.href.includes("news.ycombinator.com")) {
       if (link.href.match(/([?&])hnid=\d+/)) {
         link.href = link.href.replace(/([?&])hnid=\d+/, `$1hnid=${item.id}`);

--- a/script.js
+++ b/script.js
@@ -185,9 +185,9 @@ async function setup() {
       return;
     }
 
-    const hnidMatch = location.search.match(/[?&]hnid=(\d+)/);
-    if (hnidMatch) {
-      addHNComments(hnidMatch[1]);
+    const hnid = document.documentElement.dataset.sidehnId;
+    if (hnid) {
+      addHNComments(hnid);
     }
     return;
   }

--- a/script.js
+++ b/script.js
@@ -190,6 +190,14 @@ async function setup() {
     return;
   }
 
+  // Match the page background to #hnmain's bgcolor so the full
+  // sidebar area is filled, even when the page content is short.
+  const hnmain = document.getElementById("hnmain");
+  if (hnmain) {
+    document.documentElement.style.backgroundColor =
+      hnmain.getAttribute("bgcolor") || "#f6f6ef";
+  }
+
   const observer = new MutationObserver(addHashIDs);
   observer.observe(document.body, {
     childList: true,

--- a/script.js
+++ b/script.js
@@ -22,22 +22,21 @@ function addHNComments(id) {
     #hn-iframe {
       position: fixed;
       top: 0;
-      right: -30%;
+      right: 0;
       width: 30%;
       height: 100vh;
       border: none;
       z-index: 2147483647;
-      transition: right 0.2s ease;
       pointer-events: auto;
     }
-    #hn-iframe.visible {
-      right: 0;
+    #hn-iframe.hidden {
+      right: -30%;
     }
 
     #hn-toggle {
       position: fixed;
       top: calc(50% - 1.5rem);
-      right: 0;
+      right: 30%;
       height: 3rem;
       width: 1.5rem;
       background: hsla(21, 84%, 55%, 1.00);
@@ -48,7 +47,6 @@ function addHNComments(id) {
       color: black;
       border-radius: 0.5rem 0 0 0.5rem;
       z-index: 2147483647;
-      transition: right 0.2s ease;
       pointer-events: auto;
       font-family: sans-serif;
       display: flex;
@@ -56,14 +54,20 @@ function addHNComments(id) {
       justify-content: center;
       padding: 0;
     }
-    #hn-toggle.visible {
-      right: 30%;
+    #hn-toggle.hidden {
+      right: 0;
+    }
+
+    .transitions #hn-iframe,
+    .transitions #hn-toggle {
+      transition: right 0.2s ease;
     }
 
     @media (max-width: 1023px) {
-      #hn-iframe { width: 85%; right: -85%; }
-      #hn-iframe.visible { right: 0; }
-      #hn-toggle.visible { right: 85%; }
+      #hn-iframe { width: 85%; }
+      #hn-iframe.hidden { right: -85%; }
+      #hn-toggle:not(.hidden) { right: 85%; }
+      #hn-toggle.hidden { right: 0; }
     }
   `;
   shadow.appendChild(style);
@@ -74,46 +78,50 @@ function addHNComments(id) {
   iframe.src = `https://news.ycombinator.com/item?id=${id}`;
   shadow.appendChild(iframe);
 
-  // Toggle button
+  // Wrapper div inside shadow for toggling transitions
+  const wrapper = document.createElement("div");
+  wrapper.appendChild(iframe);
+
+  // Toggle button — starts in visible/expanded state
   const toggle = document.createElement("button");
   toggle.id = "hn-toggle";
-  toggle.textContent = "\u25C2"; // left-pointing chevron (collapsed)
-  shadow.appendChild(toggle);
+  toggle.textContent = "\u25B8"; // right-pointing chevron (expanded)
+  wrapper.appendChild(toggle);
+  shadow.appendChild(wrapper);
 
-  // Inject a <style> into the page to shrink body — the only page-side effect.
-  // Using an ID so we can toggle it without touching the page's own styles.
-  const pageStyle = document.createElement("style");
-  pageStyle.id = "sidehn-page-style";
-  pageStyle.textContent = `
-    html.sidehn-active {
-      margin-right: 30% !important;
-      transition: margin-right 0.2s ease;
-    }
-    @media (max-width: 1023px) {
-      html.sidehn-active {
-        margin-right: 0 !important;
-      }
-    }
-  `;
-  document.head.appendChild(pageStyle);
+  // Start shown on desktop
+  shown = window.innerWidth >= 1024;
+  if (!shown) {
+    iframe.classList.add("hidden");
+    toggle.classList.add("hidden");
+    toggle.textContent = "\u25C2";
+  } else {
+    document.documentElement.classList.add("sidehn-active");
+  }
+
+  function enableTransitions() {
+    wrapper.classList.add("transitions");
+    document.documentElement.classList.add("sidehn-animated");
+  }
 
   function show() {
     shown = true;
-    iframe.classList.add("visible");
-    toggle.classList.add("visible");
-    toggle.textContent = "\u25B8"; // right-pointing chevron (expanded)
+    iframe.classList.remove("hidden");
+    toggle.classList.remove("hidden");
+    toggle.textContent = "\u25B8";
     document.documentElement.classList.add("sidehn-active");
   }
 
   function hide() {
     shown = false;
-    iframe.classList.remove("visible");
-    toggle.classList.remove("visible");
+    iframe.classList.add("hidden");
+    toggle.classList.add("hidden");
     toggle.textContent = "\u25C2";
     document.documentElement.classList.remove("sidehn-active");
   }
 
   toggle.addEventListener("click", () => {
+    enableTransitions(); // transitions kick in from first interaction
     if (shown) {
       hiddenManually = true;
       hide();
@@ -135,8 +143,10 @@ function addHNComments(id) {
   // replacements don't remove it
   document.documentElement.appendChild(host);
 
-  window.addEventListener("resize", autoToggle);
-  autoToggle();
+  window.addEventListener("resize", () => {
+    enableTransitions();
+    autoToggle();
+  });
 }
 
 function addHashIDs() {

--- a/sidehn.css
+++ b/sidehn.css
@@ -1,0 +1,11 @@
+html.sidehn-active {
+  margin-right: 30% !important;
+}
+html.sidehn-animated {
+  transition: margin-right 0.2s ease;
+}
+@media (max-width: 1023px) {
+  html.sidehn-active {
+    margin-right: 0 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Rewrites sidebar injection to use a closed Shadow DOM instead of replacing `document.body.innerHTML`, which destroyed event listeners and broke React/SPA sites
- Moves all extension UI (iframe, toggle button) into an invisible `<sidehn-host>` element attached to `<html>`, so SPA body replacements can't remove it
- Adds `early.js` at `document_start` + manifest CSS to apply the page margin before first paint, eliminating the layout flash
- Removes global namespace pollution (`window.hnIframeShown`, etc.). All state lives in closures
- Uses `URL.searchParams.set` to place the query params before the hash fragment to load the sidebar properly on pages which use hash fragments in their URL.

## Files changed
- `script.js` - full rewrite of `addHNComments()`
- `early.js` - new, runs at `document_start` to set `sidehn-active` class
- `sidehn.css` - new, manifest-injected styles for page margin
- `manifest.chrome.json` / `manifest.firefox.json` - added early content script entry, bumped both to 1.0.4
- `.gitignore` - added `manifest.json` to ignore symlinked file for local development in chrome

## Known issues

### Sidebar overlays content on some sites
Sites that use `100vw` widths, `position: fixed` layouts, or other viewport-relative sizing will show the sidebar overlapping page content instead of pushing it aside. The `margin-right` approach on `<html>` works for most sites, but there's no CSS-only way to force all elements to respect it.

- **Potential fix (out of scope):** A more aggressive approach using `CSS.registerProperty` or injecting per-element overrides could help, but risks breaking site layouts in worse ways than the overlay.

### Extension doesn't load on sites that strip query params via server redirect
Some sites (e.g. phoronix.com) do a server-side 301/302 redirect that removes the `?hnid=` parameter before the page loads. Since Chrome matches content scripts against the final URL, the extension never gets injected. Client-side stripping via `history.replaceState` IS handled - `early.js` captures the hnid at `document_start` before page scripts run.

 - **Potential fix (out of scope):** Switch from `?hnid=` to a URL hash fragment (`#sidehn=123`), which survives server redirects since fragments are never sent to the server. Trade-off: content script match patterns can't match on fragments, so this would require broader content script matching and a different permission footprint. Alternatively, the background script could capture the hnid via `webNavigation.onBeforeNavigate` and inject scripts programmatically, but this adds `webNavigation`, `scripting`, and `<all_urls>` permissions.

### Security headers stripped on host pages
Rule 4 removes CSP, X-Frame-Options, and cross-origin isolation headers (COEP, COOP, CORP) from host pages loaded with `?hnid=` to allow the HN iframe to embed. This weakens the page's security hardening for that page load - notably, stripping COEP disables Spectre mitigations like `SharedArrayBuffer` process isolation on sites that opt into it. The rule only fires on `main_frame` requests containing `hnid=`, so normal browsing is unaffected.